### PR TITLE
RV3028 set & get aging offset

### DIFF
--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -2473,6 +2473,8 @@ DS3231 RTC;
 	}
 
 	//Set the EEOffset register
+	//The LSB bit (EEOffset[0]) is ignored
+	//Therefore, the saved offset is within +/-1 range
 	bool RV3028::setAgingOffset(int8_t val) {
 		int regVal = (int) val;
 		regVal = regVal <= 0 ? -regVal : (512 - regVal);
@@ -2487,7 +2489,7 @@ DS3231 RTC;
 		if (regFull <= 128) {
 			return -((int8_t) regFull);
 		}
-		regFull = MIN(512 - MIN(regFull, UINT8_MAX), INT8_MAX);
+		regFull = MIN(512 - regFull, INT8_MAX);
 		return (int8_t) regFull;
 	}
 

--- a/src/ezTime.cpp
+++ b/src/ezTime.cpp
@@ -1,5 +1,5 @@
 #include <Arduino.h>
-
+#include <sys/param.h>
 #include <ezTime.h>
 
 #ifdef EZTIME_NETWORK_ENABLE
@@ -2470,6 +2470,25 @@ DS3231 RTC;
 	//Read the status register to clear the current interrupt flags
 	void RV3028::clearInterrupts(void){
 		rv3028(RV3028_REG_STATUS, 0);
+	}
+
+	//Set the EEOffset register
+	bool RV3028::setAgingOffset(int8_t val) {
+		int regVal = (int) val;
+		regVal = regVal <= 0 ? -regVal : (512 - regVal);
+		regVal >>= 1;
+		regVal = MIN(regVal, UINT8_MAX);  // not needed because it's guaranted to be within the range
+		return rv3028(RV3028_REG_EEOffset_8_1, (uint8_t) regVal);
+	}
+
+	int8_t RV3028::getAgingOffset() {
+		uint8_t regVal = rv3028(RV3028_REG_EEOffset_8_1);
+		int regFull = ((int) regVal) << 1;
+		if (regFull <= 128) {
+			return -((int8_t) regFull);
+		}
+		regFull = MIN(512 - MIN(regFull, UINT8_MAX), INT8_MAX);
+		return (int8_t) regFull;
 	}
 
 	uint8_t RV3028::bcdToDec(uint8_t bcd) {

--- a/src/ezTime.h
+++ b/src/ezTime.h
@@ -748,8 +748,8 @@ namespace ezt {
 			static uint8_t status(); //Returns the status byte
 			static void clearInterrupts();
 
-		// 	static bool setAgingOffset(int8_t val);
-		// 	static int8_t getAgingOffset();
+			static bool setAgingOffset(int8_t val);
+			static int8_t getAgingOffset();
 
 		private:
 			static uint8_t bcdToDec(uint8_t bcd);


### PR DESCRIPTION
For simplicity and common API (`int8_t` age), only the bits at addr `36h` are saved and the first bit at addr `37h` is ignored.

RV3032 could be derived from RV3028 with different (and simpler) set and get aging offset functions.